### PR TITLE
fix: resolve hash tooltips and image converter lock icon issues

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -51,8 +51,8 @@ export default function RootLayout({
                 </main>
                 <Footer />
               </div>
-<Toaster />
               <TooltipProvider>
+                <Toaster />
                 <Analytics />
                 <SpeedInsights />
               </TooltipProvider>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,6 +13,7 @@ import { LandingBackground } from '@/components/landing-background';
 
 import { Analytics } from "@vercel/analytics/next"
 import { SpeedInsights } from "@vercel/speed-insights/next"
+import { TooltipProvider } from "@/components/ui/tooltip"
 
 export const metadata: Metadata = {
   title: 'astraa - Utility Tools Suite',
@@ -50,9 +51,11 @@ export default function RootLayout({
                 </main>
                 <Footer />
               </div>
-              <Toaster />
-              <Analytics />
-              <SpeedInsights />
+<Toaster />
+              <TooltipProvider>
+                <Analytics />
+                <SpeedInsights />
+              </TooltipProvider>
             </ActivityProvider>
           </ToolsProvider>
         </ThemeProvider>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -37,27 +37,27 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <ToolsProvider>
-            <ActivityProvider>
-              <LandingBackground />
-              <div className="min-h-screen flex flex-col">
-                <Navigation />
-                <main id="main-content" className="flex-1 w-full" tabIndex={-1}>
-                  <PageTransition type="fade">
-                    <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8 lg:py-12">
-                      {children}
-                    </div>
-                  </PageTransition>
-                </main>
-                <Footer />
-              </div>
-              <TooltipProvider>
+          <TooltipProvider>
+            <ToolsProvider>
+              <ActivityProvider>
+                <LandingBackground />
+                <div className="min-h-screen flex flex-col">
+                  <Navigation />
+                  <main id="main-content" className="flex-1 w-full" tabIndex={-1}>
+                    <PageTransition type="fade">
+                      <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8 lg:py-12">
+                        {children}
+                      </div>
+                    </PageTransition>
+                  </main>
+                  <Footer />
+                </div>
                 <Toaster />
                 <Analytics />
                 <SpeedInsights />
-              </TooltipProvider>
-            </ActivityProvider>
-          </ToolsProvider>
+              </ActivityProvider>
+            </ToolsProvider>
+          </TooltipProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/components/image/image-controls.tsx
+++ b/components/image/image-controls.tsx
@@ -67,18 +67,20 @@ export function ImageControls({
             />
           </div>
 
-          {/* Lock Button */}
-          <div className="shrink-0 pb-1">
+{/* Lock Button */}
+          <div className="shrink-0 flex items-center">
             <Button
               variant="outline"
               size="icon"
               className={cn(
-                "h-9 w-9 transition-colors",
+                "h-10 w-10 transition-colors cursor-pointer",
                 isLocked ? "bg-primary text-primary-foreground hover:bg-primary/90" : "text-muted-foreground"
               )}
               onClick={() => onLockChange(!isLocked)}
               disabled={disabled}
               title={isLocked ? "Unlock aspect ratio" : "Lock aspect ratio"}
+              aria-pressed={isLocked}
+              aria-label={isLocked ? "Unlock aspect ratio" : "Lock aspect ratio"}
             >
               {isLocked ? <Lock className="h-4 w-4" /> : <Unlock className="h-4 w-4" />}
             </Button>
@@ -97,9 +99,9 @@ export function ImageControls({
             />
           </div>
 
-          {/* Unit Display (Static px for now) */}
-          <div className="shrink-0 pb-1">
-            <div className="h-9 px-3 flex items-center justify-center bg-muted/50 border rounded-md text-sm text-muted-foreground">
+{/* Unit Display (Static px for now) */}
+          <div className="shrink-0 flex items-center">
+            <div className="h-10 px-3 flex items-center justify-center bg-muted/50 border rounded-md text-sm text-muted-foreground">
               px
             </div>
           </div>

--- a/components/image/image-controls.tsx
+++ b/components/image/image-controls.tsx
@@ -67,7 +67,7 @@ export function ImageControls({
             />
           </div>
 
-{/* Lock Button */}
+          {/* Lock Button */}
           <div className="shrink-0 flex items-center">
             <Button
               variant="outline"
@@ -99,7 +99,7 @@ export function ImageControls({
             />
           </div>
 
-{/* Unit Display (Static px for now) */}
+          {/* Unit Display (Static px for now) */}
           <div className="shrink-0 flex items-center">
             <div className="h-10 px-3 flex items-center justify-center bg-muted/50 border rounded-md text-sm text-muted-foreground">
               px

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -42,7 +42,7 @@ const CommandInput = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
 >(({ className, ...props }, ref) => (
   <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
-    <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+    <Search className="mr-2 h-4 w-4 shrink-0 text-foreground" />
     <CommandPrimitive.Input
       ref={ref}
       className={cn(

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -29,7 +29,7 @@ const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg transition-all duration-200">
-        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5 [&_[cmdk-item]_svg]:text-popover-foreground [&_[cmdk-item]]:text-popover-foreground hover:[&_[cmdk-item]]:text-popover-foreground">
           {children}
         </Command>
       </DialogContent>

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -42,7 +42,7 @@ const CommandInput = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
 >(({ className, ...props }, ref) => (
   <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
-    <Search className="mr-2 h-4 w-4 shrink-0 text-foreground" />
+    <Search className="mr-2 h-4 w-4 shrink-0" />
     <CommandPrimitive.Input
       ref={ref}
       className={cn(

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -23,13 +23,13 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-interface CommandDialogProps extends DialogProps {}
+interface CommandDialogProps extends DialogProps { }
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
-      <DialogContent className="overflow-hidden p-0 shadow-lg transition-all duration-200">
-        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5 [&_[cmdk-item]_svg]:text-popover-foreground [&_[cmdk-item]]:text-popover-foreground hover:[&_[cmdk-item]]:text-popover-foreground">
+      <DialogContent className="overflow-hidden p-0 shadow-lg transition-all duration-200 [&>button]:top-3 [&>button]:right-3">
+        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>
       </DialogContent>
@@ -129,8 +129,9 @@ const CommandItem = React.forwardRef<
       "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none",
       "transition-all duration-150 ease-in-out",
       "data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50",
-      "data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground",
-      "data-[selected='true']:scale-[0.99]",
+      "data-[selected='true']:bg-accent data-[selected='true']:text-accent-foreground",
+      // Icons follow the current text color (no special hover/selected overrides)
+      "[&_svg]:text-current",
       "hover:bg-accent/50",
       className
     )}


### PR DESCRIPTION
- Hash Generator: Fixed the "?" help button that wasn't showing tooltips by adding TooltipProvider to the root layout
- Image Converter - Alignment: Fixed vertical misalignment of the lock icon by matching its height (h-10) to the input fields and using flex items-center for proper centering
- Image Converter - Accessibility: Added aria-pressed and aria-label attributes to the lock button for screen reader support, plus cursor-pointer class for better visual feedback
- Unit Display: Also aligned the "px" display badge to match the corrected input height

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR attempts to fix tooltip issues in the hash generator and improves UI alignment in the image converter. The image converter changes are solid - lock button height was correctly adjusted from `h-9` to `h-10` to match input fields, accessibility attributes were added, and the px unit display was aligned. Command dialog styling was also improved with better icon visibility and close button positioning.

**Critical Issue:**
- The `TooltipProvider` placement in `app/layout.tsx` won't fix the hash generator tooltip issue - it only wraps `Toaster`, `Analytics`, and `SpeedInsights`, while `{children}` (containing the hash generator) renders outside this provider
- The hash generator already has its own `TooltipProvider` at `components/hash/hash-selector.tsx:44`, which should work independently
- To provide app-wide tooltip context, the provider must wrap all children that use tooltips

**What worked:**
- Image controls alignment fixes are correct and improve visual consistency
- Accessibility improvements (`aria-pressed`, `aria-label`, `cursor-pointer`) follow best practices
- Command dialog polish enhances usability

<h3>Confidence Score: 2/5</h3>


- This PR has a critical logic error that prevents it from achieving its main goal
- The primary issue this PR claims to fix (hash generator tooltips) won't be resolved due to incorrect `TooltipProvider` placement. While the image controls and command dialog changes are safe and correct, the main tooltip fix is broken.
- `app/layout.tsx` requires immediate attention - the `TooltipProvider` must be repositioned to wrap application children

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| app/layout.tsx | Added TooltipProvider wrapping Toaster, Analytics, and SpeedInsights - placement issue prevents app-wide tooltip functionality |
| components/image/image-controls.tsx | Fixed lock button vertical alignment (h-9 → h-10) and added accessibility attributes (aria-pressed, aria-label) |
| components/ui/command.tsx | Improved search icon visibility and close button positioning in command dialog |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant HashSelector
    participant TooltipProvider
    participant Tooltip
    participant Layout

    User->>HashSelector: Hover over ? button
    HashSelector->>TooltipProvider: Request tooltip context
    Note over TooltipProvider: Local provider at<br/>component level
    TooltipProvider->>Tooltip: Provide context
    Tooltip->>User: Show description

    Note over Layout: TooltipProvider added<br/>wrapping Analytics/SpeedInsights<br/>(not children/app content)
    
    User->>Layout: App renders
    Layout->>Layout: TooltipProvider wraps<br/>only Toaster, Analytics,<br/>SpeedInsights
    Note over Layout: Children (including HashSelector)<br/>rendered outside TooltipProvider
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->