### PR TITLE
fix(password): use theme tokens for copy/refresh buttons instead of hardcoded colors

### DIFF
--- a/components/password/password-generator.tsx
+++ b/components/password/password-generator.tsx
@@ -236,7 +236,7 @@ export function PasswordGeneratorClient() {
             <Button
               size="lg"
               variant="outline"
-              className="w-full font-semibold text-base h-12"
+              className="w-full font-semibold text-base h-12 hover:bg-muted/50 hover:text-foreground"
               onClick={generate}
             >
               Refresh password

--- a/components/password/password-generator.tsx
+++ b/components/password/password-generator.tsx
@@ -227,7 +227,8 @@ export function PasswordGeneratorClient() {
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <Button
               size="lg"
-              className="w-full bg-blue-600 hover:bg-blue-700 text-white font-semibold text-base h-12"
+              variant="default"
+              className="w-full font-semibold text-base h-12"
               onClick={handleCopyToClipboard}
             >
               Copy password
@@ -235,7 +236,7 @@ export function PasswordGeneratorClient() {
             <Button
               size="lg"
               variant="outline"
-              className="w-full font-semibold text-base h-12 border-2 hover:bg-muted/50"
+              className="w-full font-semibold text-base h-12"
               onClick={generate}
             >
               Refresh password


### PR DESCRIPTION
## Summary
Fixes the Copy and Refresh password buttons to use the app's theme system instead of hardcoded Tailwind colors, and fixes the pink hover on the Refresh button in dark mode.
## Changes
- **Copy password button**: Replaced hardcoded `bg-blue-600 hover:bg-blue-700 text-white` with `variant="default"` — uses theme tokens (`bg-primary text-primary-foreground hover:bg-primary/90`)
- **Refresh password button**: Replaced `variant="outline"` default hover (`hover:bg-accent` which resolves to pink in dark mode) with `hover:bg-muted/50 hover:text-foreground` to match the project's standard secondary hover pattern
## Linked Issue
Closes #
## Checklist
- [x] Target branch is `development` (not `main`)
- [ ] Tests pass locally (`npm test`)
- [x] Build succeeds (`npm run build`)
- [x] Tested on mobile and desktop
- [x] Tested in dark and light themes
- [x] Follows project conventions (double quotes, semicolons, 2-space indent)